### PR TITLE
handle BasePointerRelative symbols in decompile

### DIFF
--- a/src/decompile.rs
+++ b/src/decompile.rs
@@ -2076,6 +2076,10 @@ impl Decompiler {
                         register_relative_names.borrow_mut().push(x.name.to_string().to_string());
                     }
 
+                    pdb2::SymbolData::BasePointerRelative(x) => {
+                        register_relative_names.borrow_mut().push(x.name.to_string().to_string());
+                    }
+
                     pdb2::SymbolData::FrameProcedure(x) => {
                         frame_procedures.borrow_mut().push(x.clone());
                     }
@@ -2319,6 +2323,29 @@ impl Decompiler {
                         )?,
                         value: None,
                         // comment: Some(format!("r{} offset {}", register_relative_symbol.register.0, register_relative_symbol.offset))
+                        comment: None,
+                    }));
+                }
+
+                pdb2::SymbolData::BasePointerRelative(base_pointer_relative_symbol) => {
+                    statements.push(cpp::Statement::Variable(cpp::Variable {
+                        signature: cpp::type_name(
+                            &mut self.class_table,
+                            &mut self.type_sizes,
+                            &mut self.type_names,
+                            context.machine_type,
+                            &context.type_info,
+                            &context.type_finder,
+                            cpp::TypeNameQuery {
+                                type_index: base_pointer_relative_symbol.type_index,
+                                modifier: None,
+                                declaration_name: Some(base_pointer_relative_symbol.name.to_string().to_string()),
+                                parameter_names: None,
+                                include_this: None,
+                                force_return_type: false,
+                            },
+                        )?,
+                        value: None,
                         comment: None,
                     }));
                 }


### PR DESCRIPTION
i had a issue trying to use this project on a PDB, but Claude Fable did the following fix in order for it to finally work for the PDB I was using:

> the symbol name is now pushed into register_relative_names and a corresponding cpp::Statement::Variable is emitted using cpp::type_name (with declaration_name set to the symbol name). this ensures base-pointer-relative locals are discovered and declared during decompilation.